### PR TITLE
Feature/frontend4anonymouspost

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -117,6 +117,23 @@ if (document.readyState === 'loading') {
 			search.init();
 			overrides.overrideTimeago();
 			hooks.fire('action:app.load');
+			$(window).on('action:composer.enhanced', function (ev, data) {
+				const container = data.postContainer;
+				const postData = data.postData || {};
+				if (postData.action !== 'topics.post') {
+					return;
+				}
+				if (container.find('.composer-anonymous-wrap').length) {
+					return;
+				}
+				const uuid = container.attr('data-uuid') || 'new';
+				const id = 'composer-anonymous-post-' + uuid;
+				const row = $('<div class="composer-anonymous-wrap mb-2"><div class="form-check"><input class="form-check-input" type="checkbox" id="' + id + '" data-composer-anonymous /><label class="form-check-label" for="' + id + '">Post anonymously</label></div></div>');
+				container.find('.title-container').first().after(row);
+				container.find('[data-composer-anonymous]').on('change', function () {
+					container.attr('data-anonymous-post', $(this).prop('checked') ? '1' : '0');
+				});
+			});
 			messages.show();
 			appLoaded = true;
 		});


### PR DESCRIPTION
Addresses #5 
demo version  button for anonymous post creation with checkbox state data-anonymous-post boolean for toggle.
added demo frontend button for anonymous post creation (can be modified for better placement / aesthetic later). stores data-anonymous-post as bool 1 or 0 in container as toggle. 

When its further developed we could add a cache so it can remember toggle / untoggle within a user session
