### PR TITLE
added LaTeX in toolbar

### DIFF
--- a/patches/nodebb-plugin-composer-default+10.3.1.patch
+++ b/patches/nodebb-plugin-composer-default+10.3.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl b/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl
-index 5b148ec..60a68ad 100644
+index 5b148ec..8b48fb0 100644
 --- a/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl
 +++ b/node_modules/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl
 @@ -53,6 +53,12 @@
@@ -8,7 +8,7 @@ index 5b148ec..60a68ad 100644
  
 +		<li title="LaTeX Editor">
 +			<button data-format="latex" class="btn btn-sm btn-link text-reset" aria-label="LaTeX Editor">
-+				<span class="latex-logo">L<sup>A</sup>T<sub>E</sub>X</span>
++				<span class="latex-logo">LaTeX</span>
 +			</button>
 +		</li>
 +

--- a/patches/nodebb-plugin-markdown+13.2.3.patch
+++ b/patches/nodebb-plugin-markdown+13.2.3.patch
@@ -21,10 +21,10 @@ index ae4091f..c90f857 100644
  		}
  	});
 diff --git a/node_modules/nodebb-plugin-markdown/public/scss/default.scss b/node_modules/nodebb-plugin-markdown/public/scss/default.scss
-index 88d319a..6d86e96 100644
+index 88d319a..2589001 100644
 --- a/node_modules/nodebb-plugin-markdown/public/scss/default.scss
 +++ b/node_modules/nodebb-plugin-markdown/public/scss/default.scss
-@@ -72,3 +72,27 @@ a.plugin-markdown-hidden-link {
+@@ -72,3 +72,12 @@ a.plugin-markdown-hidden-link {
  		border-radius: var(--bs-border-radius) !important;
  	}
  }
@@ -35,21 +35,6 @@ index 88d319a..6d86e96 100644
 +	font-style: normal;
 +	font-weight: normal;
 +	font-size: 1em;
-+	letter-spacing: 0.01em;
 +	white-space: nowrap;
-+
-+	sup {
-+		font-size: 0.75em;
-+		vertical-align: 0.35em;
-+		margin-left: -0.3em;
-+		margin-right: -0.12em;
-+	}
-+
-+	sub {
-+		font-size: 0.85em;
-+		vertical-align: -0.3em;
-+		margin-left: -0.12em;
-+		margin-right: -0.05em;
-+	}
 +}
 \ No newline at end of file


### PR DESCRIPTION
### Context

The composer toolbar currently only supports standard Markdown formatting. As the first step toward LaTeX math support, users need a way to access a LaTeX editor from the composer. This PR adds the button that will eventually open a split-pane LaTeX editor modal (input on the left, preview on the right). Related issue: #9 

### Description

Added a "LaTeX" button to the composer formatting bar, positioned after the file upload buttons. The button is styled with a serif font to visually represent the LaTeX brand. On click, it fires an action:composer.latex-editor.open hook that will be connected to the editor modal in a follow-up PR.

Changes are made to node_modules plugins and persisted using patch-package:

### Changes

patches/nodebb-plugin-composer-default+10.3.1.patch
Modifies static/templates/partials/composer-formatting.tpl to add a <li> with a data-format="latex" button after the upload buttons, using the same btn btn-sm btn-link text-reset classes as existing toolbar buttons
patches/nodebb-plugin-markdown+13.2.3.patch
Modifies public/js/markdown.js to register a latex entry in the formatting dispatch table via formatting.addButtonDispatch(), following the same pattern as bold, italic, and other handlers
Modifies public/scss/default.scss to add .formatting-bar .latex-logo CSS styling with a serif font stack

Note: since package.json is gitignored, after pulling this branch and running npm install you might need to apply the patches manually by npx patch-package.