### PR TITLE
Add unit tests to Latex plugin

### DIFF
--- a/test/plugins-composer-latex.js
+++ b/test/plugins-composer-latex.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const path = require('path');
+
+// Run LaTeX plugin unit tests (same pattern as post-fields-logger)
+const pluginTestPath = path.join(__dirname, '../vendor/nodebb-plugin-composer-latex/test/composer-latex.js');
+require(pluginTestPath);

--- a/vendor/nodebb-plugin-composer-latex/test/composer-latex.js
+++ b/vendor/nodebb-plugin-composer-latex/test/composer-latex.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('assert');
+const plugin = require('../library.js');
+
+describe('Composer LaTeX Plugin', () => {
+	describe('registerFormatting', () => {
+		it('should add latex option to formatting payload', async () => {
+			const payload = { options: [] };
+			await plugin.registerFormatting(payload);
+			assert(Array.isArray(payload.options));
+			assert(payload.options.length >= 1);
+			const latexOption = payload.options.find(o => o.name === 'latex');
+			assert(latexOption, 'should have a latex option');
+			assert.strictEqual(latexOption.name, 'latex');
+			assert(latexOption.title);
+			assert.strictEqual(latexOption.className, 'fa fa-superscript');
+			assert(latexOption.visibility);
+			assert.strictEqual(latexOption.visibility.mobile, true);
+			assert.strictEqual(latexOption.visibility.desktop, true);
+		});
+
+		it('should preserve existing options when adding latex', async () => {
+			const payload = { options: [{ name: 'bold' }] };
+			await plugin.registerFormatting(payload);
+			assert(payload.options.some(o => o.name === 'bold'));
+			assert(payload.options.some(o => o.name === 'latex'));
+		});
+
+		it('should create options array if missing', async () => {
+			const payload = {};
+			await plugin.registerFormatting(payload);
+			assert(Array.isArray(payload.options));
+			assert(payload.options.some(o => o.name === 'latex'));
+		});
+	});
+
+	describe('addMathJaxScript', () => {
+		it('should add MathJax script to templateData.useCustomHTML', async () => {
+			const data = { templateData: {} };
+			await plugin.addMathJaxScript(data);
+			assert(data.templateData.useCustomHTML);
+			assert(data.templateData.useCustomHTML.includes('mathjax'));
+			assert(data.templateData.useCustomHTML.includes('script'));
+			assert(data.templateData.useCustomHTML.includes('cdn.jsdelivr.net'));
+		});
+
+		it('should append to existing useCustomHTML if present', async () => {
+			const data = { templateData: { useCustomHTML: '<div>custom</div>' } };
+			await plugin.addMathJaxScript(data);
+			assert(data.templateData.useCustomHTML.includes('<div>custom</div>'));
+			assert(data.templateData.useCustomHTML.includes('mathjax'));
+		});
+
+		it('should do nothing if templateData is missing', async () => {
+			const data = {};
+			await plugin.addMathJaxScript(data);
+			assert.strictEqual(data.templateData, undefined);
+		});
+	});
+});


### PR DESCRIPTION
[https://github.com/CMU-313/nodebb-spring-26-kernel-panic/issues/9](url) 
**Context** The composer latex plugin (nodebb-plugin-composer-latex) adds a button to the composer toolbar and mathjax support for math equations. It current has no unit tests in the NodeBB test suite. Adding such tests will give confidence that the plugin behaves as intended and helps catch errors when the plugin or NodeBB core changes. 

**Description** This PR adds unit tests for the composer latex plugin by wiring its tests into the NodeBB test suite (similar approach used for nodebb-plugin-post-fields) `registerFormatting` adds a Latex option to the composer formatting payload `addMathJaxScript` injects mathjax config and script into the template data so posts can render latex 

**Changes in code database** 
`test/plugins-composer-latex.js` 
`vendor/nodebb-plugin-composer-latex/test/composer-latex.js` 

**Additional** Uses mocha and node's built in assert. tests run with `npm test`